### PR TITLE
Bot mmorpg ai issues

### DIFF
--- a/modelhub/diagnostics/health_probe.py
+++ b/modelhub/diagnostics/health_probe.py
@@ -37,6 +37,35 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# Issue #76: every subprocess we read text from must pin an explicit
+# encoding AND an error handler.
+#
+# The sidecar runs under PYTHONUTF8=1 / PYTHONIOENCODING=utf-8 (set by
+# the Tauri shell), so `text=True` decodes child output as UTF-8. Windows
+# console tools do not honour that -- on a Russian install `tasklist`
+# emits cp866, and the first Cyrillic byte blew up inside
+# subprocess's reader THREAD:
+#
+#   Exception in thread Thread-13 (_readerthread):
+#     File "subprocess.py", line 1515, in _readerthread
+#     File "codecs.py", line 322, in decode
+#   UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8a in position 44
+#
+# Because that raises off the main thread, `subprocess.run` returned a
+# CompletedProcess with stdout=None instead of propagating; the AV probe
+# then died on `rc.stdout.lower()` and every debug bundle from a
+# non-English Windows was missing its antivirus section while the
+# training log filled with tracebacks that looked like a training crash.
+#
+# errors="replace" keeps the probe lossy-but-alive: a mojibake process
+# name is still greppable, an exploded reader thread is not.
+_SUBPROCESS_TEXT_KWARGS: Dict[str, Any] = {
+    "capture_output": True,
+    "text": True,
+    "encoding": "utf-8",
+    "errors": "replace",
+}
+
 # How many bytes of each file to hash when computing the integrity prefix.
 # Full-file hash on python-runtime.zip (~220 MB) would block the UI for
 # seconds; first 1 MB is plenty to catch truncation / corruption.
@@ -279,11 +308,10 @@ def _embedded_python_health(install_dir: Path) -> Dict[str, Any]:
     try:
         rc = subprocess.run(
             [str(py), "--version"],
-            capture_output=True,
-            text=True,
             timeout=5,
+            **_SUBPROCESS_TEXT_KWARGS,
         )
-        out["version"] = (rc.stdout + rc.stderr).strip()
+        out["version"] = ((rc.stdout or "") + (rc.stderr or "")).strip()
         out["runs"] = rc.returncode == 0
     except Exception as e:  # noqa: BLE001
         out["version_error"] = f"{type(e).__name__}: {e}"
@@ -299,9 +327,8 @@ def _embedded_python_health(install_dir: Path) -> Dict[str, Any]:
         try:
             r = subprocess.run(
                 [str(py), "-c", f"import {pkg}"],
-                capture_output=True,
-                text=True,
                 timeout=10,
+                **_SUBPROCESS_TEXT_KWARGS,
             )
             importable[pkg] = r.returncode == 0
         except Exception:  # noqa: BLE001
@@ -393,13 +420,12 @@ def _antivirus_hint() -> Dict[str, Any]:
         # so we don't have to deal with column-aligned parsing.
         rc = subprocess.run(
             ["tasklist", "/FO", "CSV", "/NH"],
-            capture_output=True,
-            text=True,
             timeout=5,
+            **_SUBPROCESS_TEXT_KWARGS,
         )
         if rc.returncode != 0:
             return {"error": f"tasklist exit={rc.returncode}"}
-        out_lower = rc.stdout.lower()
+        out_lower = (rc.stdout or "").lower()
         for proc in suspects:
             if proc.lower() in out_lower:
                 found.append(proc)

--- a/scripts/runtime_doctor.py
+++ b/scripts/runtime_doctor.py
@@ -37,7 +37,7 @@ Exit codes
 Output schema
 -------------
   {
-    "doctor_version": "1.0.0",
+    "doctor_version": "1.1.0",
     "verdict": "ok" | "warning" | "error",
     "elapsed_ms": int,
     "platform": {os, python_version, executable, prefix},
@@ -74,7 +74,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import Callable, List, Optional
 
-DOCTOR_VERSION = "1.0.0"
+DOCTOR_VERSION = "1.1.0"
 
 
 # --------------------------------------------------------------------------
@@ -178,10 +178,42 @@ def _resolve_pkg_root(pkg: str) -> str:
     return "<not found on sys.path>"
 
 
+def _missing_submodule_context(pkg_root: str, missing: str) -> str:
+    """Describe where a missing submodule *should* live on disk.
+
+    Issue #75: users reported `No module named 'torch._strobelight'`
+    while the doctor's detail talked exclusively about torch/testing/ --
+    one bundle even showed `torch_testing_dir_exists=True` right next to
+    advice to un-quarantine torch/testing. The name of the module that
+    actually failed, and whether ITS directory exists, is the
+    diagnostic; the torch.testing story was a hard-coded leftover from
+    the first bug of this class.
+
+    Returns a "path=... exists=..." fragment, or "" when we can't map it.
+    """
+    if not missing or pkg_root == "<not found on sys.path>":
+        return ""
+    parts = missing.split(".")
+    if len(parts) < 2:
+        return ""
+    # torch._strobelight -> <torch_root>/_strobelight
+    rel = os.path.join(*parts[1:])
+    candidate = os.path.join(pkg_root, rel)
+    exists = os.path.isdir(candidate) or os.path.isfile(candidate + ".py")
+    return f" | missing_module_path={candidate} | missing_module_path_exists={exists}"
+
+
 def _check_torch_intact() -> CheckResult:
     # The whole reason this doctor exists: a previous build prune
     # deleted torch/testing/. Verify the FULL torch surface, not
     # just the top-level package.
+    #
+    # `import torch` alone is NOT sufficient: torch's own __init__ pulls
+    # in a long tail of private subpackages (torch._strobelight among
+    # them, issue #75), so a partial extract that loses one of those
+    # fails at `import torch` with a name the operator has never heard
+    # of. We probe the public surface explicitly and let the exception
+    # carry whichever private module actually went missing.
     import importlib
 
     submodules = ["torch", "torch.testing", "torch.fx", "torch.nn", "torch.utils.data"]
@@ -199,9 +231,9 @@ def _check_torch_intact() -> CheckResult:
         # production failures: missing subpackages after partial extract /
         # AV quarantine, and DLL-load crashes from wheel corruption. The
         # `torch_testing_dir_exists` boolean is the smoking gun for the
-        # AV-quarantine pattern: if Python can't import torch.testing AND
-        # the directory is gone from disk, an external actor (Defender,
-        # corporate AV) deleted it after extraction.
+        # AV-quarantine pattern: if Python can't import torch AND the
+        # testing directory is gone from disk, an external actor
+        # (Defender, corporate AV) deleted it after extraction.
         torch_root = _resolve_pkg_root("torch")
         testing_dir = (
             os.path.join(torch_root, "testing")
@@ -209,16 +241,50 @@ def _check_torch_intact() -> CheckResult:
             else "<unknown>"
         )
         testing_exists = os.path.isdir(testing_dir) if testing_dir != "<unknown>" else False
-        return CheckResult(
-            "torch_intact",
-            "error",
+
+        # Which module actually failed? ModuleNotFoundError carries it on
+        # `.name`; fall back to parsing the message for other importers.
+        missing = getattr(e, "name", "") or ""
+        if not missing:
+            import re as _re
+
+            m = _re.search(r"No module named '([^']+)'", str(e))
+            missing = m.group(1) if m else ""
+
+        detail = (
             f"{type(e).__name__}: {e} | torch_root={torch_root} | "
-            f"torch_testing_dir_exists={testing_exists}. "
-            "Likely partial/corrupted runtime extract or antivirus quarantine. "
-            "Click [Add AV Exclusion] then [Repair Runtime] in the UI -- "
-            "the order matters: AV exclusion first prevents the re-quarantine "
-            "of torch/testing/ during re-extraction.",
+            f"torch_testing_dir_exists={testing_exists}"
         )
+        if missing:
+            detail += f" | missing_module={missing}"
+            detail += _missing_submodule_context(torch_root, missing)
+        detail += ". "
+
+        # Remediation, tailored to the failure that actually happened.
+        # Recommending "AV exclusion then Repair Runtime" for a module
+        # the shipped zip never contained sends users in a circle --
+        # which is exactly what issue #75 reported after following the
+        # old advice.
+        if missing and missing != "torch.testing" and testing_exists:
+            detail += (
+                f"The rest of torch is present, so this is not a broad "
+                f"quarantine -- '{missing}' alone is missing from the "
+                "installed package. Re-extracting the same bundle will not "
+                "add a file it never had: use [Repair PyTorch via pip] "
+                "(Settings -> System Tools), which downloads a fresh torch "
+                "wheel from upstream. Add the AV exclusion first if you run "
+                "third-party antivirus."
+            )
+        else:
+            detail += (
+                "Likely partial/corrupted runtime extract or antivirus "
+                "quarantine. Click [Add AV Exclusion] then [Repair Runtime] "
+                "in the UI -- the order matters: AV exclusion first prevents "
+                "the re-quarantine of torch/testing/ during re-extraction. "
+                "If that does not clear it, use [Repair PyTorch via pip]."
+            )
+
+        return CheckResult("torch_intact", "error", detail)
 
 
 def _check_torchvision_intact() -> CheckResult:

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -276,6 +276,56 @@ fn normalize_game_id(game_id: Option<String>) -> String {
     }
 }
 
+/// Architecture allow-list. Mirrors MODEL_REGISTRY in
+/// src/bot_mmorpg/scripts/models_pytorch.py (the single source of truth
+/// -- 2-train_model.py forwards to it via get_model()). Adding a new
+/// model class? Add it to the backend registry first, then here.
+///
+/// Also mirrors DEFAULT_ARCHITECTURES in tauri-ui/main.js, which the UI
+/// uses as its fallback catalog. `custom` is a synthetic value the UI
+/// never emits, kept as a no-op for safety.
+///
+/// Phase 25: was out of sync (had `resnet50`, which does not exist in
+/// the registry, and was missing every modern / advanced / legacy arch
+/// the UI offers), so the train preflight rejected valid archs like
+/// `efficientnet_simple` with "Unknown architecture".
+const KNOWN_ARCHS: &[&str] = &[
+    "custom",
+    // Modern (recommended)
+    "efficientnet_lstm",
+    "efficientnet_simple",
+    "mobilenet_v3",
+    // Alias: 14 shipped game profiles spell it this way. The Python
+    // side normalises it via MODEL_ALIASES, so accept it here rather
+    // than blocking the action with "Unknown architecture".
+    "mobilenetv3",
+    "resnet18_lstm",
+    // Advanced (experimental)
+    "efficientnet_transformer",
+    "multihead_action",
+    "game_attention",
+    // Legacy (backward compatibility)
+    "inception_v3",
+    "alexnet",
+    "sentnet",
+    "sentnet_2d",
+];
+
+/// True when `s` is a bare architecture id rather than a model path.
+///
+/// Issue #76: the UI's fallback catalog advertises architectures with
+/// `path == id`, so an activated architecture reaches the bot preflight
+/// as a `model_dir` that is a single token like "efficientnet_lstm".
+/// Anything containing a path separator is a real (if possibly stale)
+/// directory and must NOT be reported as an architecture.
+fn is_architecture_id(s: &str) -> bool {
+    let t = s.trim();
+    if t.is_empty() || t.contains('/') || t.contains('\\') {
+        return false;
+    }
+    KNOWN_ARCHS.contains(&t)
+}
+
 /// Dev repo root helper (src-tauri parent)
 fn dev_repo_root() -> PathBuf {
     std::env::current_dir()
@@ -4966,35 +5016,8 @@ async fn preflight_action(
                     ));
                 }
             }
-            // Architecture allow-list. Mirrors MODEL_REGISTRY in
-            // src/bot_mmorpg/scripts/models_pytorch.py (the single
-            // source of truth -- 2-train_model.py forwards to it via
-            // get_model()).  Adding a new model class? Add it to the
-            // backend registry first, then add the same key here.
-            //
-            // Phase 25: was out of sync (had `resnet50` which doesn't
-            // exist in the registry, and was missing every modern /
-            // advanced / legacy arch the UI offers), so the train
-            // preflight rejected valid archs like `efficientnet_simple`
-            // with "Unknown architecture". Plus `custom` -- a synthetic
-            // value the UI never emits but kept as a no-op for safety.
-            const KNOWN_ARCHS: &[&str] = &[
-                "custom",
-                // Modern (recommended)
-                "efficientnet_lstm",
-                "efficientnet_simple",
-                "mobilenet_v3",
-                "resnet18_lstm",
-                // Advanced (experimental)
-                "efficientnet_transformer",
-                "multihead_action",
-                "game_attention",
-                // Legacy (backward compatibility)
-                "inception_v3",
-                "alexnet",
-                "sentnet",
-                "sentnet_2d",
-            ];
+            // Architecture allow-list lives at module scope (see
+            // KNOWN_ARCHS) so is_architecture_id() shares it.
             let a = arch.unwrap_or_else(|| "custom".to_string());
             if !KNOWN_ARCHS.contains(&a.as_str()) {
                 reasons.push(format!(
@@ -5024,10 +5047,26 @@ async fn preflight_action(
                                 .to_string(),
                         );
                     } else if !Path::new(model_dir).exists() {
-                        reasons.push(format!(
-                            "Active model directory missing on disk: {}. The model was deleted or moved -- pick another in the Models tab.",
-                            model_dir
-                        ));
+                        // Issue #76: distinguish "the folder vanished"
+                        // from "you activated an architecture template".
+                        // The UI's fallback catalog (used whenever the
+                        // sidecar reports no bundled builtins, i.e. every
+                        // Custom Game) lists architectures with
+                        // path == the arch id, so a user who clicked Set
+                        // Active on one stored model_dir="efficientnet_lstm"
+                        // and was then told their model had been "deleted
+                        // or moved" -- naming a folder that never existed.
+                        if is_architecture_id(model_dir) {
+                            reasons.push(format!(
+                                "'{}' is a training architecture, not a trained model. Architectures are templates: record a dataset, train it with '{}' in the Train tab, then activate the resulting model in the Models tab.",
+                                model_dir, model_dir
+                            ));
+                        } else {
+                            reasons.push(format!(
+                                "Active model directory missing on disk: {}. The model was deleted or moved -- pick another in the Models tab.",
+                                model_dir
+                            ));
+                        }
                     }
                 }
                 Err(_) => {
@@ -6700,6 +6739,63 @@ mod tests {
     fn test_normalize_game_id_whitespace_only() {
         let result = normalize_game_id(Some("   ".to_string()));
         assert_eq!(result, DEFAULT_GAME_ID);
+    }
+
+    // --- is_architecture_id (issue #76) ---
+    //
+    // The UI's fallback catalog advertises architectures with
+    // path == id, so an activated architecture reaches the bot
+    // preflight as a bare token. Telling that user their model was
+    // "deleted or moved" was the single most confusing message in
+    // issue #76 -- it named a directory that never existed.
+
+    #[test]
+    fn test_is_architecture_id_recognises_bare_arch() {
+        assert!(is_architecture_id("efficientnet_lstm"));
+        assert!(is_architecture_id("resnet18_lstm"));
+        assert!(is_architecture_id("  mobilenet_v3  "));
+    }
+
+    #[test]
+    fn test_is_architecture_id_rejects_paths() {
+        // A real model dir must never be misreported as a template,
+        // even when its LAST component happens to be an arch name.
+        assert!(!is_architecture_id(
+            "C:\\Users\\x\\AppData\\Local\\com.bot.mmorpg.ai\\trained_models\\custom\\efficientnet_lstm"
+        ));
+        assert!(!is_architecture_id("trained_models/custom/efficientnet_lstm"));
+    }
+
+    #[test]
+    fn test_is_architecture_id_rejects_unknown_and_empty() {
+        assert!(!is_architecture_id(""));
+        assert!(!is_architecture_id("   "));
+        assert!(!is_architecture_id("my_trained_model_v3"));
+    }
+
+    #[test]
+    fn test_known_archs_covers_ui_default_architectures() {
+        // Guards the mobilenet_v3 / mobilenetv3 split that made the
+        // train preflight reject a model the UI itself offered.
+        let ui_defaults = [
+            "efficientnet_lstm",
+            "efficientnet_simple",
+            "mobilenet_v3",
+            "mobilenetv3",
+            "resnet18_lstm",
+            "efficientnet_transformer",
+            "multihead_action",
+            "game_attention",
+            "inception_v3",
+            "alexnet",
+        ];
+        for arch in ui_defaults {
+            assert!(
+                KNOWN_ARCHS.contains(&arch),
+                "UI offers architecture '{}' that the train preflight rejects",
+                arch
+            );
+        }
     }
 
     // --- parse_ready_line ---

--- a/src/bot_mmorpg/config/hardware_detector.py
+++ b/src/bot_mmorpg/config/hardware_detector.py
@@ -138,19 +138,29 @@ class HardwareDetector:
                     ["sysctl", "-n", "hw.memsize"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=5,
                 )
                 if result.returncode == 0:
-                    return int(result.stdout.strip()) // (1024 * 1024)
+                    return int((result.stdout or "").strip()) // (1024 * 1024)
             elif system == "Windows":
+                # Issue #76: pin the codec. Under PYTHONUTF8=1 the
+                # default text decode is UTF-8, but wmic emits the OEM
+                # codepage on localized Windows -- the UnicodeDecodeError
+                # is raised inside subprocess's reader thread, so it does
+                # not surface here as an exception, it just prints a
+                # traceback and leaves stdout as None.
                 result = subprocess.run(
                     ["wmic", "OS", "get", "TotalVisibleMemorySize"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=5,
                 )
                 if result.returncode == 0:
-                    lines = result.stdout.strip().split("\n")
+                    lines = (result.stdout or "").strip().split("\n")
                     if len(lines) > 1:
                         kb = int(lines[1].strip())
                         return kb // 1024

--- a/src/bot_mmorpg/scripts/models_pytorch.py
+++ b/src/bot_mmorpg/scripts/models_pytorch.py
@@ -1181,6 +1181,35 @@ MODEL_INFO: Dict[str, Dict[str, Any]] = {
 }
 
 
+# Architecture ids that appear in shipped game profiles and older UI
+# builds but are not MODEL_REGISTRY keys.
+#
+# Issue #76: every Custom Game starts from
+# game_profiles/_template/profile.yaml, which specifies `mobilenetv3`
+# (14 shipped profiles do). MODEL_REGISTRY only knows `mobilenet_v3`, so
+# get_model() raised "Unknown model: mobilenetv3" and the training job
+# died before the first epoch -- with the traceback buried in the
+# sidecar log rather than surfaced in the UI.
+#
+# Normalising here (rather than mass-editing the profiles) also covers
+# profiles users wrote themselves against the documented spelling.
+MODEL_ALIASES: Dict[str, str] = {
+    "mobilenetv3": "mobilenet_v3",
+    "mobilenet-v3": "mobilenet_v3",
+    "mobilenet_v3_small": "mobilenet_v3",
+}
+
+
+def resolve_model_name(model_name: str) -> str:
+    """Map a profile/UI-supplied architecture id onto a registry key.
+
+    Unknown names pass through unchanged so the caller still raises a
+    "Unknown model: ..." error naming what the user actually asked for.
+    """
+    key = str(model_name or "").strip().lower()
+    return MODEL_ALIASES.get(key, key)
+
+
 def list_models() -> List[str]:
     """Return list of available model names."""
     return list(MODEL_REGISTRY.keys())
@@ -1188,9 +1217,10 @@ def list_models() -> List[str]:
 
 def get_model_info(model_name: str) -> Dict[str, Any]:
     """Get metadata about a model."""
-    if model_name not in MODEL_INFO:
+    resolved = resolve_model_name(model_name)
+    if resolved not in MODEL_INFO:
         raise ValueError(f"Unknown model: {model_name}. Available: {list_models()}")
-    return MODEL_INFO[model_name]
+    return MODEL_INFO[resolved]
 
 
 def get_model(
@@ -1217,6 +1247,10 @@ def get_model(
         model = get_model('efficientnet_lstm', num_actions=29)
         model = get_model('mobilenet_v3', num_actions=29, pretrained=False)
     """
+    # Issue #76: profiles ship `mobilenetv3`, the registry key is
+    # `mobilenet_v3`. Normalise before every lookup below.
+    model_name = resolve_model_name(model_name)
+
     if model_name not in MODEL_REGISTRY:
         raise ValueError(f"Unknown model: {model_name}. Available: {list_models()}")
 

--- a/tauri-ui/main.js
+++ b/tauri-ui/main.js
@@ -23,8 +23,75 @@ const BUILD_TAG = "%BUILD_TAG%";
 window.__BUILD_TAG__ = BUILD_TAG;
 
 // State & Tauri Globals
-const invoke = window.__TAURI__ ? window.__TAURI__.invoke : null;
+const __rawInvoke = window.__TAURI__ ? window.__TAURI__.invoke : null;
 const listen = window.__TAURI__ ? window.__TAURI__.event.listen : null;
+
+// ---------------------------------------------------------------
+// Issues #70 / #76: the argument-name bridge.
+//
+// Tauri derives each command's argument struct with serde's default
+// camelCase renaming, so a Rust handler declared as
+//
+//     async fn list_datasets(game_id: Option<String>)
+//
+// expects the JS payload key `gameId` -- NOT `game_id`. Half of this
+// file was written against the snake_case names, which produced two
+// distinct failure classes depending on the Rust type:
+//
+//   Option<T> args  -> silently deserialize to None. `list_datasets`,
+//                      `mh_get_catalog_data`, `generate_dataset_name`,
+//                      `open_datasets_folder` and `delete_dataset` all
+//                      dropped `game_id` and fell back to
+//                      DEFAULT_GAME_ID ("genshin_impact"). Recording
+//                      wrote to datasets/<custom game>/ (start_recording
+//                      happened to send both key styles) while every
+//                      listing read datasets/genshin_impact/ -- so a
+//                      custom-game recording existed on disk but never
+//                      appeared in the Train tab. That is issue #70
+//                      verbatim, including why "select Genshin Impact"
+//                      was a working workaround.
+//   Required args   -> hard error. `modelhub_validate_model` produced
+//                      "invalid args `modelDir` ... missing required
+//                      key modelDir" (issue #76).
+//
+// Rather than hand-patch every call site (and re-break on the next one
+// added), normalize centrally: every payload key is emitted in BOTH
+// snake_case and camelCase. Serde ignores the unknown twin, so this is
+// safe for handlers using either convention, including any older
+// shipped binary a user upgrades from.
+// ---------------------------------------------------------------
+function __toCamel(key) {
+  return key.replace(/_+([a-z0-9])/g, (_, c) => c.toUpperCase());
+}
+
+function __toSnake(key) {
+  return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function normalizeInvokeArgs(args) {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return args;
+  const out = { ...args };
+  for (const [k, v] of Object.entries(args)) {
+    const camel = __toCamel(k);
+    const snake = __toSnake(k);
+    // Never overwrite a key the caller set explicitly -- a call site
+    // that already sends both forms stays authoritative.
+    if (camel !== k && !(camel in out)) out[camel] = v;
+    if (snake !== k && !(snake in out)) out[snake] = v;
+  }
+  return out;
+}
+
+const invoke = __rawInvoke
+  ? (cmd, args, options) =>
+      args === undefined || args === null
+        ? __rawInvoke(cmd)
+        : __rawInvoke(cmd, normalizeInvokeArgs(args), options)
+  : null;
+
+// Exposed for the UI regression tests (and for debug bundles, where
+// seeing the exact payload the shell received is worth a lot).
+window.__normalizeInvokeArgs = normalizeInvokeArgs;
 
 // Global State
 let isRecording = false;
@@ -137,17 +204,11 @@ function applyHealthGate(verdict) {
 async function preflightOrAlert(kind, params) {
   if (!invoke) return { ok: true, reasons: [] };
   try {
-    // Bridge hardening: some shipped runtimes bind command args via
-    // camelCase names while our UI state uses snake_case keys. Emit
-    // both forms for preflight payloads so either binding convention
-    // receives the same values.
-    const payload = { kind, ...params };
-    Object.entries(params || {}).forEach(([k, v]) => {
-      if (!k.includes("_")) return;
-      const camel = k.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-      if (!(camel in payload)) payload[camel] = v;
-    });
-    const res = await invoke("preflight_action", payload);
+    // Bridge hardening now lives in normalizeInvokeArgs() (see the
+    // invoke wrapper at the top of this file), which emits both the
+    // snake_case and camelCase form of every key for EVERY command --
+    // preflight_action was only one of a dozen affected call sites.
+    const res = await invoke("preflight_action", { kind, ...params });
     if (res && res.ok) return res;
     const reasons = (res && Array.isArray(res.reasons) && res.reasons.length)
       ? res.reasons
@@ -683,7 +744,11 @@ const DEFAULT_GAMES = Object.values(GAME_PRESETS).map(g => ({
 const DEFAULT_ARCHITECTURES = [
   { id: "efficientnet_lstm", name: "EfficientNet-LSTM (Recommended)", recommended: true, tier: "modern" },
   { id: "efficientnet_simple", name: "EfficientNet (Balanced)", tier: "modern" },
-  { id: "mobilenetv3", name: "MobileNetV3 (Fast)", tier: "modern" },
+  // Registry key is `mobilenet_v3` (MODEL_REGISTRY in
+  // src/bot_mmorpg/scripts/models_pytorch.py). This list used to say
+  // `mobilenetv3`, which the train preflight rejected as "Unknown
+  // architecture" and which get_model() would have raised on anyway.
+  { id: "mobilenet_v3", name: "MobileNetV3 (Fast)", tier: "modern" },
   { id: "resnet18_lstm", name: "ResNet18-LSTM", tier: "modern" },
   { id: "efficientnet_transformer", name: "EfficientNet-Transformer (Advanced)", tier: "advanced" },
   { id: "multihead_action", name: "Multi-Head Action (Simultaneous)", tier: "advanced" },
@@ -846,6 +911,23 @@ function labelForBuiltin(b) {
 }
 function valueForBuiltin(b) {
   return b.path || b.id || "";
+}
+
+// Issue #76: when the sidecar reports no bundled builtin models (the
+// normal case for a Custom Game), loadCatalog falls back to
+// DEFAULT_ARCHITECTURES and synthesises entries whose `path` is just
+// the architecture id ("efficientnet_lstm"). Those are training
+// TEMPLATES, not model folders -- activating one stored
+// model_dir="efficientnet_lstm" and the bot preflight then rejected the
+// run with "Active model directory missing on disk: efficientnet_lstm",
+// which reads like the user deleted something they never had.
+//
+// A real builtin always carries a filesystem path. So: no separator +
+// a known architecture id == a template, never a deployable model.
+function isArchitectureTemplatePath(p) {
+  const s = String(p || "").trim();
+  if (!s || s.includes("/") || s.includes("\\")) return false;
+  return DEFAULT_ARCHITECTURES.some((a) => a.id === s);
 }
 
 function labelForLocalModel(m) {
@@ -1393,6 +1475,24 @@ async function setActiveModelFromUI() {
 
   if (!path) {
     alert("Select a model (local/builtin/registry) first.");
+    return;
+  }
+
+  // Issue #76: block the "activated an architecture template" trap at
+  // the source instead of letting it fail later inside the bot
+  // preflight with a misleading "model directory missing on disk".
+  if (isArchitectureTemplatePath(path)) {
+    const msg =
+      `"${path}" is a training architecture, not a trained model.\n\n` +
+      "Architectures are templates you pick in the Train tab. Record a " +
+      "dataset, train it with this architecture, then activate the " +
+      "resulting model from the Trained Models section.";
+    logToTerminal(`Set Active rejected: ${path} is an architecture template, not a trained model.`, "warning");
+    if (window.notifyError) {
+      window.notifyError("Not a trained model", msg);
+    } else {
+      alert(msg);
+    }
     return;
   }
 

--- a/tests/test_issue_70_75_76_regressions.py
+++ b/tests/test_issue_70_75_76_regressions.py
@@ -1,0 +1,617 @@
+"""
+Regression tests for GitHub issues #70, #75 and #76.
+
+Each test in this file pins the specific defect a user reported, so a
+future refactor that reintroduces it fails here rather than in someone's
+living room.
+
+  #70  "Dataset not appearing after recording for me either"
+       A custom-game recording landed on disk but never showed up in the
+       Train tab. Root cause: tauri-ui/main.js invoked the Rust commands
+       with snake_case argument keys (`game_id`) while Tauri derives its
+       argument structs with serde's default camelCase renaming
+       (`gameId`). For `Option<T>` arguments the key was silently
+       dropped, so every listing fell back to DEFAULT_GAME_ID
+       ("genshin_impact") -- which is exactly why "just select Genshin
+       Impact" was the working workaround in the issue thread.
+
+  #75  "Backend failed to start"
+       ModuleNotFoundError: No module named 'torch._strobelight', while
+       the runtime doctor's remediation text talked only about
+       torch/testing/ -- in one bundle right next to
+       `torch_testing_dir_exists=True`. Users followed advice that could
+       not fix their failure.
+
+  #76  Program does not see the training files (RU). Same camelCase
+       bridge as #70, plus three follow-on defects visible in the
+       attached logs:
+         - `invalid args 'modelDir' ... missing required key modelDir`
+           (the required-argument flavour of the same bug)
+         - "Active model directory missing on disk: efficientnet_lstm"
+           (an architecture template activated as if it were a model)
+         - UnicodeDecodeError inside subprocess's reader thread while
+           decoding `tasklist` output on a localized Windows.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+UI_JS = ROOT / "tauri-ui" / "main.js"
+RUST_MAIN = ROOT / "src-tauri" / "src" / "main.rs"
+DOCTOR_PATH = ROOT / "scripts" / "runtime_doctor.py"
+MODELS_PY = ROOT / "src" / "bot_mmorpg" / "scripts" / "models_pytorch.py"
+VERSIONED_MODELS_PY = ROOT / "versions" / "0.01" / "models_pytorch.py"
+GAME_PROFILES = ROOT / "game_profiles"
+
+
+# =====================================================================
+# Helpers: static extraction from the JS / Rust sources
+# =====================================================================
+
+# Arguments Tauri injects itself -- never part of the JS payload.
+_INJECTED_ARG_TYPES = ("tauri::State", "AppHandle", "Window", "tauri::Window")
+
+
+def _rust_commands() -> dict[str, list[tuple[str, bool]]]:
+    """Map every #[tauri::command] fn to its caller-supplied arguments.
+
+    Each entry is ``(arg_name, is_optional)`` -- an ``Option<T>``
+    argument deserializes to ``None`` when the key is absent (the silent
+    failure mode of #70), while a bare ``String`` hard-errors with
+    "missing required key" (the #76 flavour).
+    """
+    src = RUST_MAIN.read_text(encoding="utf-8", errors="replace")
+    commands: dict[str, list[str]] = {}
+    pattern = re.compile(
+        r"#\[tauri::command(?:\([^)]*\))?\]\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)\s*\(([^)]*)\)",
+        re.S,
+    )
+    for match in pattern.finditer(src):
+        name = match.group(1)
+        raw_args = re.sub(r"//[^\n]*", "", match.group(2))
+
+        # Split on top-level commas only (generics contain their own).
+        params, depth, current = [], 0, ""
+        for ch in raw_args:
+            if ch in "<([":
+                depth += 1
+            elif ch in ">)]":
+                depth -= 1
+            if ch == "," and depth == 0:
+                params.append(current)
+                current = ""
+            else:
+                current += ch
+        params.append(current)
+
+        arg_names = []
+        for param in params:
+            param = param.strip()
+            if not param or ":" not in param:
+                continue
+            arg_name, arg_type = (p.strip() for p in param.split(":", 1))
+            if any(t in arg_type for t in _INJECTED_ARG_TYPES):
+                continue
+            arg_names.append((arg_name, arg_type.startswith("Option<")))
+        commands[name] = arg_names
+    return commands
+
+
+def _js_invocations() -> list[tuple[str, set[str], bool]]:
+    """Extract (command, payload keys, has_spread) for every invoke()."""
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    out: list[tuple[str, set[str], bool]] = []
+    # Match invoke("cmd", { ... }) allowing one level of object nesting.
+    pattern = re.compile(
+        r"""invoke\(\s*["'](\w+)["']\s*(?:,\s*(\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}))?""",
+        re.S,
+    )
+    for match in pattern.finditer(js):
+        obj = match.group(2) or ""
+        keys = set(re.findall(r"([A-Za-z_]\w*)\s*:", obj))
+        # Shorthand properties: { provider, api_key }. Lookahead on both
+        # delimiters -- a consuming match would eat the comma that the
+        # next shorthand key needs and silently drop it.
+        keys |= set(re.findall(r"(?<=[{,])\s*([A-Za-z_]\w*)\s*(?=[,}])", obj))
+        out.append((match.group(1), keys, "..." in obj))
+    return out
+
+
+def _to_camel(key: str) -> str:
+    """Mirror serde's default rename_all = "camelCase" for arg names."""
+    head, *rest = key.split("_")
+    return head + "".join(part[:1].upper() + part[1:] for part in rest if part)
+
+
+def _normalize_invoke_args(keys: set[str]) -> set[str]:
+    """Python mirror of normalizeInvokeArgs() in tauri-ui/main.js."""
+    out = set(keys)
+    for key in keys:
+        out.add(_to_camel(key))
+        out.add(re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key).lower())
+    return out
+
+
+# =====================================================================
+# Issue #70 / #76: the Tauri argument-name bridge
+# =====================================================================
+
+
+def test_ui_wraps_invoke_with_arg_normalizer():
+    """main.js must route every invoke through normalizeInvokeArgs."""
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    assert "function normalizeInvokeArgs" in js
+    assert "normalizeInvokeArgs(args)" in js, (
+        "The invoke wrapper must actually call the normalizer -- defining "
+        "it without wiring it up is how issue #70 shipped."
+    )
+    # The raw handle stays available for the wrapper, but nothing else
+    # may bind `invoke` straight to it and bypass normalization.
+    assert re.search(r"const\s+invoke\s*=\s*window\.__TAURI__", js) is None, (
+        "`invoke` must be the normalizing wrapper, not window.__TAURI__.invoke"
+    )
+
+
+def test_normalize_invoke_args_emits_both_key_styles():
+    """The normalizer's contract, verified against the real JS via node."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not available")
+
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    start = js.index("function __toCamel(")
+    end = js.index("const invoke =", start)
+    harness = (
+        js[start:end]
+        + "\nconsole.log(JSON.stringify(normalizeInvokeArgs("
+        + '{game_id: "custom", modelDir: "C:/m", path: "p"}'
+        + ")));\n"
+    )
+    result = subprocess.run(
+        [node, "-e", harness],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    # snake -> camel (this is the direction issue #70 needed)
+    assert payload["gameId"] == "custom"
+    assert payload["game_id"] == "custom"
+    # camel -> snake (so a handler using rename_all="snake_case" works)
+    assert payload["model_dir"] == "C:/m"
+    assert payload["modelDir"] == "C:/m"
+    # Single-word keys are untouched, no duplicates invented.
+    assert payload["path"] == "p"
+
+
+def test_normalize_invoke_args_never_overwrites_explicit_keys():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not available")
+
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    start = js.index("function __toCamel(")
+    end = js.index("const invoke =", start)
+    harness = (
+        js[start:end]
+        + "\nconsole.log(JSON.stringify(normalizeInvokeArgs("
+        + '{game_id: "snake", gameId: "camel"}'
+        + ")));\n"
+    )
+    result = subprocess.run(
+        [node, "-e", harness],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["gameId"] == "camel", "explicit caller keys must win"
+    assert payload["game_id"] == "snake"
+
+
+def test_every_invoke_target_is_a_registered_command():
+    registered = _rust_commands()
+    unknown = sorted({cmd for cmd, _, _ in _js_invocations() if cmd not in registered})
+    assert not unknown, (
+        "main.js invokes commands with no #[tauri::command] handler: "
+        f"{unknown}. These fail at runtime with 'command not found'."
+    )
+
+
+def test_every_invoke_payload_reaches_its_rust_handler():
+    """The #70/#76 root cause, pinned.
+
+    After normalization every declared Rust argument must be present in
+    the payload under the camelCase name Tauri deserializes. Call sites
+    that build their payload with a spread are checked for required
+    arguments only -- the spread's contents are not statically known.
+    """
+    registered = _rust_commands()
+    failures: list[str] = []
+
+    for cmd, keys, has_spread in _js_invocations():
+        if cmd not in registered:
+            continue  # covered by the test above
+        delivered = _normalize_invoke_args(keys)
+        for arg, is_optional in registered[cmd]:
+            if is_optional and has_spread:
+                continue
+            expected = _to_camel(arg)
+            if expected not in delivered:
+                failures.append(
+                    f"{cmd}: Rust expects '{expected}' (from `{arg}`), "
+                    f"JS sends {sorted(keys) or '{}'}"
+                )
+
+    assert not failures, "Tauri argument bridge broken:\n  " + "\n  ".join(failures)
+
+
+def test_dataset_listing_commands_carry_the_game_id():
+    """The precise call sites that made custom-game datasets invisible."""
+    invocations = {cmd: keys for cmd, keys, _ in _js_invocations()}
+    for cmd in (
+        "mh_get_catalog_data",
+        "list_datasets",
+        "generate_dataset_name",
+        "delete_dataset",
+        "open_datasets_folder",
+    ):
+        assert cmd in invocations, f"{cmd} is no longer invoked from main.js"
+        delivered = _normalize_invoke_args(invocations[cmd])
+        assert "gameId" in delivered, (
+            f"{cmd} does not deliver a game id, so it silently falls back to "
+            "DEFAULT_GAME_ID and custom-game datasets disappear (issue #70)."
+        )
+
+
+# =====================================================================
+# Issue #76: architecture templates are not deployable models
+# =====================================================================
+
+
+def test_ui_rejects_activating_an_architecture_template():
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    assert "function isArchitectureTemplatePath" in js
+    start = js.index("async function setActiveModelFromUI")
+    end = js.index("\nasync function deleteSelectedModel", start)
+    set_active = js[start:end]
+    assert "isArchitectureTemplatePath(path)" in set_active, (
+        "Set Active must reject bare architecture ids before they are "
+        "stored as the active model_dir (issue #76)."
+    )
+
+
+def test_rust_preflight_distinguishes_architecture_from_missing_dir():
+    rust = RUST_MAIN.read_text(encoding="utf-8", errors="replace")
+    assert "fn is_architecture_id(" in rust
+    assert "is_architecture_id(model_dir)" in rust, (
+        "The bot preflight must not report an activated architecture as a "
+        "model directory that was 'deleted or moved' (issue #76)."
+    )
+
+
+def test_ui_default_architectures_match_the_model_registry():
+    """`mobilenetv3` in the UI vs `mobilenet_v3` in MODEL_REGISTRY meant
+    the train preflight rejected an architecture the UI itself offered."""
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    start = js.index("const DEFAULT_ARCHITECTURES")
+    end = js.index("];", start)
+    block = js[start:end]
+    ui_ids = re.findall(r'\{\s*id:\s*"([^"]+)"', block)
+    assert ui_ids, "DEFAULT_ARCHITECTURES parse failed"
+
+    known = _model_registry_keys() | _model_aliases().keys()
+    unknown = sorted(set(ui_ids) - known)
+    assert not unknown, f"UI offers architectures unknown to MODEL_REGISTRY: {unknown}"
+
+
+# =====================================================================
+# Issue #76: architecture aliases (shipped profiles say `mobilenetv3`)
+# =====================================================================
+
+
+def _models_module_ast(path: pathlib.Path = MODELS_PY) -> ast.Module:
+    """Parse models_pytorch.py without importing it (needs torch)."""
+    return ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+
+
+def _dict_literal(tree: ast.Module, name: str) -> dict[str, str]:
+    for node in tree.body:
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                assert isinstance(value, ast.Dict)
+                out = {}
+                for k, v in zip(value.keys, value.values):
+                    key = k.value if isinstance(k, ast.Constant) else None
+                    if key is None:
+                        continue
+                    out[key] = v.value if isinstance(v, ast.Constant) else v.id
+                return out
+    raise AssertionError(f"{name} not found in {MODELS_PY.name}")
+
+
+def _model_registry_keys(path: pathlib.Path = MODELS_PY) -> set[str]:
+    return set(_dict_literal(_models_module_ast(path), "MODEL_REGISTRY"))
+
+
+def _model_aliases(path: pathlib.Path = MODELS_PY) -> dict[str, str]:
+    return _dict_literal(_models_module_ast(path), "MODEL_ALIASES")
+
+
+def test_model_aliases_all_point_at_real_registry_keys():
+    registry = _model_registry_keys()
+    for alias, target in _model_aliases().items():
+        assert target in registry, (
+            f"MODEL_ALIASES['{alias}'] -> '{target}' is not a MODEL_REGISTRY key"
+        )
+        assert alias not in registry, (
+            f"'{alias}' is both an alias and a registry key -- pick one"
+        )
+
+
+def test_mobilenetv3_profile_spelling_is_aliased():
+    """14 shipped profiles say `mobilenetv3`; get_model() knows
+    `mobilenet_v3` and raised ValueError before the first epoch."""
+    assert _model_aliases().get("mobilenetv3") == "mobilenet_v3"
+
+
+def test_every_shipped_game_profile_architecture_is_trainable():
+    if not GAME_PROFILES.is_dir():
+        pytest.skip("game_profiles/ not present")
+
+    known = _model_registry_keys() | _model_aliases().keys()
+    offenders: list[str] = []
+    for profile in sorted(GAME_PROFILES.rglob("profile.yaml")):
+        text = profile.read_text(encoding="utf-8", errors="replace")
+        for arch in re.findall(r'(?:recommended_)?architecture:\s*"([^"]+)"', text):
+            if arch not in known:
+                offenders.append(f"{profile.relative_to(ROOT)}: {arch}")
+    assert not offenders, (
+        "Game profiles reference architectures get_model() cannot build:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_versioned_models_copy_carries_the_alias_fix():
+    """versions/0.01/ is what the installer ships and what training
+    actually imports at runtime -- it must not drift from src/."""
+    assert VERSIONED_MODELS_PY.exists()
+    assert _model_aliases(VERSIONED_MODELS_PY) == _model_aliases()
+    assert "resolve_model_name(model_name)" in VERSIONED_MODELS_PY.read_text(
+        encoding="utf-8", errors="replace"
+    )
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("torch") is None, reason="PyTorch required"
+)
+def test_get_model_accepts_the_profile_spelling():
+    sys.path.insert(0, str(ROOT / "src"))
+    from bot_mmorpg.scripts.models_pytorch import (  # noqa: PLC0415
+        get_model_info,
+        resolve_model_name,
+    )
+
+    assert resolve_model_name("mobilenetv3") == "mobilenet_v3"
+    assert resolve_model_name("MobileNetV3") == "mobilenet_v3"
+    assert resolve_model_name("efficientnet_lstm") == "efficientnet_lstm"
+    # Unknown names pass through so the error still names what was asked.
+    assert resolve_model_name("nonsense_arch") == "nonsense_arch"
+    assert get_model_info("mobilenetv3")["name"]
+
+
+# =====================================================================
+# Issue #76: subprocess output decoding on localized Windows
+# =====================================================================
+
+
+def test_health_probe_pins_subprocess_encoding():
+    from modelhub.diagnostics import health_probe  # noqa: PLC0415
+
+    kwargs = health_probe._SUBPROCESS_TEXT_KWARGS
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace", (
+        "Without errors='replace' a cp866 byte from tasklist raises "
+        "UnicodeDecodeError inside subprocess's reader thread (issue #76)."
+    )
+    assert kwargs["text"] is True and kwargs["capture_output"] is True
+
+
+def test_health_probe_has_no_unpinned_text_subprocess():
+    """Every subprocess.run in the probe must go through the shared
+    kwargs -- a new unpinned call reintroduces the crash."""
+    src = (ROOT / "modelhub" / "diagnostics" / "health_probe.py").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    tree = ast.parse(src)
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "run"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
+            continue
+        keywords = {kw.arg for kw in node.keywords}
+        if None in keywords:  # **_SUBPROCESS_TEXT_KWARGS
+            continue
+        if "text" in keywords and "encoding" not in keywords:
+            offenders.append(node.lineno)
+    assert not offenders, (
+        f"subprocess.run with text=True but no encoding= at line(s) {offenders}"
+    )
+
+
+def test_antivirus_hint_survives_undecodable_output(monkeypatch):
+    """Simulate the Russian-Windows tasklist that produced the
+    UnicodeDecodeError traceback pasted into issue #76."""
+    from modelhub.diagnostics import health_probe  # noqa: PLC0415
+
+    probe = getattr(health_probe, "_antivirus_hint", None)
+    if probe is None:
+        pytest.skip("_antivirus_hint not present")
+
+    captured: dict = {}
+
+    class _Result:
+        returncode = 0
+        # What errors="replace" yields for cp866 bytes read as UTF-8.
+        stdout = '"\ufffd\ufffd\ufffd.exe","1234"\n"MsMpEng.exe","4321"\n'
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return _Result()
+
+    # The probe short-circuits off Windows; we are testing the Windows
+    # code path, so claim to be there.
+    monkeypatch.setattr(health_probe.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(health_probe.subprocess, "run", fake_run)
+    result = probe()
+
+    assert captured.get("encoding") == "utf-8"
+    assert captured.get("errors") == "replace"
+    assert "error" not in result, f"probe degraded instead of reporting: {result}"
+    assert "MsMpEng.exe" in result.get("detected", [])
+
+
+# =====================================================================
+# Issue #75: torch._strobelight diagnosis
+# =====================================================================
+
+
+@pytest.fixture(scope="module")
+def doctor():
+    spec = importlib.util.spec_from_file_location("runtime_doctor_i75", DOCTOR_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["runtime_doctor_i75"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fail_torch_import(monkeypatch, missing: str):
+    import importlib as _il
+
+    real_import = _il.import_module
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torch":
+            raise ModuleNotFoundError(f"No module named '{missing}'", name=missing)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(_il, "import_module", fake_import)
+
+
+def _fake_torch_tree(monkeypatch, doctor, tmp_path, keep_testing: bool):
+    """Stand in for an installed torch so the detail has a real root."""
+    torch_root = tmp_path / "site-packages" / "torch"
+    torch_root.mkdir(parents=True)
+    if keep_testing:
+        (torch_root / "testing").mkdir()
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(torch_root))
+    return torch_root
+
+
+def test_doctor_names_the_module_that_actually_failed(doctor, monkeypatch, tmp_path):
+    """Issue #75: the detail said 'torch/testing' for a failure that was
+    nothing to do with torch/testing."""
+    _fake_torch_tree(monkeypatch, doctor, tmp_path, keep_testing=True)
+    _fail_torch_import(monkeypatch, "torch._strobelight")
+    result = doctor._check_torch_intact()
+
+    assert result.status == "error"
+    assert "missing_module=torch._strobelight" in result.detail, (
+        "The doctor must report WHICH submodule failed; a bundle that only "
+        "says 'torch/testing' sends the user after the wrong file."
+    )
+    assert "missing_module_path_exists=False" in result.detail
+
+
+def test_doctor_recommends_pip_repair_for_a_single_missing_subpackage(
+    doctor, monkeypatch, tmp_path
+):
+    """Re-extracting the same zip cannot add a file it never contained,
+    so the remediation for this signature is the pip path.
+
+    This is the exact bundle from issue #75: torch._strobelight missing
+    while torch_testing_dir_exists=True.
+    """
+    _fake_torch_tree(monkeypatch, doctor, tmp_path, keep_testing=True)
+    _fail_torch_import(monkeypatch, "torch._strobelight")
+    result = doctor._check_torch_intact()
+
+    assert "torch_testing_dir_exists=True" in result.detail
+    assert "Repair PyTorch via pip" in result.detail
+    assert "not a broad" in result.detail, (
+        "Advice that blames a broad AV quarantine is wrong when the rest "
+        "of the torch tree is present -- that is what sent #75 in circles."
+    )
+
+
+def test_doctor_still_blames_quarantine_when_the_tree_is_gutted(
+    doctor, monkeypatch, tmp_path
+):
+    """The original bug-#9 signature must keep its original advice."""
+    _fake_torch_tree(monkeypatch, doctor, tmp_path, keep_testing=False)
+    _fail_torch_import(monkeypatch, "torch.testing")
+    result = doctor._check_torch_intact()
+
+    assert "torch_testing_dir_exists=False" in result.detail
+    assert "AV Exclusion" in result.detail
+    assert "Repair Runtime" in result.detail
+
+
+def test_missing_submodule_context_maps_dotted_names_to_paths(doctor, tmp_path):
+    torch_root = tmp_path / "torch"
+    (torch_root / "_strobelight").mkdir(parents=True)
+
+    present = doctor._missing_submodule_context(str(torch_root), "torch._strobelight")
+    assert "missing_module_path_exists=True" in present
+
+    absent = doctor._missing_submodule_context(str(torch_root), "torch.testing")
+    assert "missing_module_path_exists=False" in absent
+
+    # Unresolvable inputs degrade to an empty fragment, never a crash.
+    assert (
+        doctor._missing_submodule_context("<not found on sys.path>", "torch.fx") == ""
+    )
+    assert doctor._missing_submodule_context(str(torch_root), "torch") == ""
+    assert doctor._missing_submodule_context(str(torch_root), "") == ""
+
+
+def test_doctor_report_still_parses_end_to_end(doctor):
+    """Schema guard: the enriched detail must not break JSON output."""
+    report = doctor.run_selftest()
+    payload = json.loads(doctor.report_to_json(report))
+    assert payload["doctor_version"] == doctor.DOCTOR_VERSION
+    names = {check["name"] for check in payload["checks"]}
+    assert {"torch_intact", "torchvision_intact", "numpy_intact"} <= names

--- a/versions/0.01/models_pytorch.py
+++ b/versions/0.01/models_pytorch.py
@@ -1181,6 +1181,35 @@ MODEL_INFO: Dict[str, Dict[str, Any]] = {
 }
 
 
+# Architecture ids that appear in shipped game profiles and older UI
+# builds but are not MODEL_REGISTRY keys.
+#
+# Issue #76: every Custom Game starts from
+# game_profiles/_template/profile.yaml, which specifies `mobilenetv3`
+# (14 shipped profiles do). MODEL_REGISTRY only knows `mobilenet_v3`, so
+# get_model() raised "Unknown model: mobilenetv3" and the training job
+# died before the first epoch -- with the traceback buried in the
+# sidecar log rather than surfaced in the UI.
+#
+# Normalising here (rather than mass-editing the profiles) also covers
+# profiles users wrote themselves against the documented spelling.
+MODEL_ALIASES: Dict[str, str] = {
+    "mobilenetv3": "mobilenet_v3",
+    "mobilenet-v3": "mobilenet_v3",
+    "mobilenet_v3_small": "mobilenet_v3",
+}
+
+
+def resolve_model_name(model_name: str) -> str:
+    """Map a profile/UI-supplied architecture id onto a registry key.
+
+    Unknown names pass through unchanged so the caller still raises a
+    "Unknown model: ..." error naming what the user actually asked for.
+    """
+    key = str(model_name or "").strip().lower()
+    return MODEL_ALIASES.get(key, key)
+
+
 def list_models() -> List[str]:
     """Return list of available model names."""
     return list(MODEL_REGISTRY.keys())
@@ -1188,9 +1217,10 @@ def list_models() -> List[str]:
 
 def get_model_info(model_name: str) -> Dict[str, Any]:
     """Get metadata about a model."""
-    if model_name not in MODEL_INFO:
+    resolved = resolve_model_name(model_name)
+    if resolved not in MODEL_INFO:
         raise ValueError(f"Unknown model: {model_name}. Available: {list_models()}")
-    return MODEL_INFO[model_name]
+    return MODEL_INFO[resolved]
 
 
 def get_model(
@@ -1217,6 +1247,10 @@ def get_model(
         model = get_model('efficientnet_lstm', num_actions=29)
         model = get_model('mobilenet_v3', num_actions=29, pretrained=False)
     """
+    # Issue #76: profiles ship `mobilenetv3`, the registry key is
+    # `mobilenet_v3`. Normalise before every lookup below.
+    model_name = resolve_model_name(model_name)
+
     if model_name not in MODEL_REGISTRY:
         raise ValueError(f"Unknown model: {model_name}. Available: {list_models()}")
 


### PR DESCRIPTION
Fix custom-game dataset visibility, arch mismatch and torch diagnosis
Issues https://github.com/ruslanmv/BOT-MMORPG-AI/issues/70, https://github.com/ruslanmv/BOT-MMORPG-AI/issues/75, https://github.com/ruslanmv/BOT-MMORPG-AI/issues/76.

Tauri argument-name bridge (https://github.com/ruslanmv/BOT-MMORPG-AI/issues/70, https://github.com/ruslanmv/BOT-MMORPG-AI/issues/76)
-------------------------------------
Tauri derives command argument structs with serde's default camelCase
renaming, so `async fn list_datasets(game_id: Option<String>)` expects
the payload key `gameId`. Much of tauri-ui/main.js was written against
the snake_case names, producing two failure classes:

  Option<T> args silently deserialized to None, so list_datasets,
  mh_get_catalog_data, generate_dataset_name, open_datasets_folder and
  delete_dataset all fell back to DEFAULT_GAME_ID. start_recording
  happened to send both key styles, so a custom-game recording was
  written to datasets/<game>/ while every listing read
  datasets/genshin_impact/ -- the recording existed on disk but never
  appeared in the Train tab (https://github.com/ruslanmv/BOT-MMORPG-AI/issues/70), and "select Genshin Impact" worked
  around it.

  Required args hard-errored: "invalid args `modelDir` ... missing
  required key modelDir" (https://github.com/ruslanmv/BOT-MMORPG-AI/issues/76).

Fixed centrally by routing invoke() through normalizeInvokeArgs(), which
emits every payload key in both snake_case and camelCase; serde ignores
the unused twin. Replaces the per-call-site workaround that existed only
in preflightOrAlert.

Architecture ids (https://github.com/ruslanmv/BOT-MMORPG-AI/issues/76)
----------------------
- The UI's fallback catalog listed `mobilenetv3` while MODEL_REGISTRY
  has `mobilenet_v3`, so the train preflight rejected an architecture
  the UI itself offered. Corrected the id.
- 14 shipped game profiles also spell it `mobilenetv3`, so get_model()
  raised "Unknown model" before the first epoch. Added MODEL_ALIASES +
  resolve_model_name() (mirrored into versions/0.01/) and normalised in
  get_model()/get_model_info().
- Activating a builtin architecture stored model_dir="efficientnet_lstm"
  -- a template, not a folder -- and the bot preflight then reported the
  model was "deleted or moved", naming a directory that never existed.
  Set Active now rejects architecture templates up front, and the
  preflight distinguishes the two cases via is_architecture_id().
  KNOWN_ARCHS moved to module scope so both paths share one list.

Subprocess decoding (https://github.com/ruslanmv/BOT-MMORPG-AI/issues/76)
-------------------------
tasklist emits the OEM codepage; under PYTHONUTF8=1 the text=True decode
raised UnicodeDecodeError inside subprocess's reader thread, leaving
stdout=None and filling the training log with tracebacks that looked
like training crashes. Pinned encoding="utf-8", errors="replace" on the
health-probe and hardware-detector subprocess calls.

Runtime doctor (https://github.com/ruslanmv/BOT-MMORPG-AI/issues/75)
--------------------
`No module named 'torch._strobelight'` was reported with remediation
text about torch/testing/ -- in one bundle right beside
torch_testing_dir_exists=True -- sending users after the wrong file. The
doctor now reports which submodule actually failed and whether its path
exists, and recommends Repair PyTorch via pip when the rest of the torch
tree is intact (re-extracting the bundle cannot add a file it never
had). The original broad-quarantine advice is unchanged for the
gutted-tree case. DOCTOR_VERSION -> 1.1.0.

Tests
-----
tests/test_issue_70_75_76_regressions.py (21 tests) pins each defect;
17 of them fail against the pre-fix tree. Adds four Rust unit tests for
is_architecture_id / KNOWN_ARCHS.