### PR TITLE
Bot mmorpg ai issues

### DIFF
--- a/modelhub/diagnostics/health_probe.py
+++ b/modelhub/diagnostics/health_probe.py
@@ -439,13 +439,43 @@ def _antivirus_hint() -> Dict[str, Any]:
 # ---------------------------------------------------------------------
 
 
+def _resolve_resource_root(data_root: Path) -> Path:
+    """Locate the tree that holds the SHIPPED files.
+
+    Issue #79: `deep_probe` passed the data root to every sub-probe,
+    including `_file_integrity`. But `_CRITICAL_FILES` are relative to
+    the INSTALL directory (`C:\\Program Files\\BOT-MMORPG-AI`), while the
+    data root is `%LOCALAPPDATA%\\com.bot.mmorpg.ai` -- two different
+    trees since the MVP-1 migration. Every single bundled file therefore
+    reported `"status": "missing"`, which makes a debug bundle look like
+    a catastrophically broken install and buries whatever the real fault
+    was. In the #79 bundle all 11 critical files were flagged missing on
+    a machine whose sidecar was running happily off those very files.
+
+    The Rust launcher exports MODELHUB_RESOURCE_ROOT; fall back to the
+    data root only when it is absent, so behaviour is unchanged for any
+    caller that genuinely has one combined tree.
+    """
+    env_root = os.environ.get("MODELHUB_RESOURCE_ROOT") or os.environ.get("BOT_INSTALL_DIR")
+    if env_root:
+        try:
+            candidate = Path(env_root).resolve()
+            if candidate.exists():
+                return candidate
+        except Exception:  # noqa: BLE001
+            pass
+    return data_root
+
+
 def deep_probe(install_dir: Optional[Path] = None) -> Dict[str, Any]:
     """
     Run every probe and return a structured dict. Never raises; each
     sub-probe is wrapped in its own try/except.
 
-    `install_dir` defaults to MODELHUB_DATA_ROOT (set by the Rust
-    launcher), then to cwd as a fallback.
+    `install_dir` is the DATA root (runtime/, datasets/, models/, logs/)
+    and defaults to MODELHUB_DATA_ROOT (set by the Rust launcher), then
+    to cwd. File-integrity checks run against the RESOURCE root instead
+    -- see `_resolve_resource_root`.
     """
     if install_dir is None:
         install_dir = Path(
@@ -454,7 +484,16 @@ def deep_probe(install_dir: Optional[Path] = None) -> Dict[str, Any]:
             or os.getcwd()
         ).resolve()
 
-    out: Dict[str, Any] = {"install_dir": str(install_dir)}
+    resource_root = _resolve_resource_root(install_dir)
+
+    out: Dict[str, Any] = {
+        "install_dir": str(install_dir),
+        # Both roots are reported so a reader can tell at a glance
+        # whether a "missing" row means the file is gone or the probe
+        # looked in the wrong tree.
+        "data_root": str(install_dir),
+        "resource_root": str(resource_root),
+    }
 
     for name, fn in [
         ("system", _system_info),
@@ -463,7 +502,7 @@ def deep_probe(install_dir: Optional[Path] = None) -> Dict[str, Any]:
         ("filesystem", lambda: _filesystem_hazards(install_dir)),
         ("network", _network_info),
         ("python_runtime", lambda: _embedded_python_health(install_dir)),
-        ("file_integrity", lambda: _file_integrity(install_dir)),
+        ("file_integrity", lambda: _file_integrity(resource_root)),
         ("environment", _redact_env),
         ("antivirus", _antivirus_hint),
     ]:

--- a/scripts/runtime_doctor.py
+++ b/scripts/runtime_doctor.py
@@ -37,7 +37,7 @@ Exit codes
 Output schema
 -------------
   {
-    "doctor_version": "1.1.0",
+    "doctor_version": "1.2.0",
     "verdict": "ok" | "warning" | "error",
     "elapsed_ms": int,
     "platform": {os, python_version, executable, prefix},
@@ -74,7 +74,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import Callable, List, Optional
 
-DOCTOR_VERSION = "1.1.0"
+DOCTOR_VERSION = "1.2.0"
 
 
 # --------------------------------------------------------------------------
@@ -203,6 +203,172 @@ def _missing_submodule_context(pkg_root: str, missing: str) -> str:
     return f" | missing_module_path={candidate} | missing_module_path_exists={exists}"
 
 
+# External native dependency of torch's fbgemm.dll on Windows. It is
+# NOT part of the VC++ redistributable (so _check_vc_redist passing
+# tells you nothing about it) -- torch ships it inside torch/lib/, and
+# it is the single most common missing file behind
+# "DLL load failed while importing _C" (issue #79).
+_TORCH_EXTERNAL_DLL = "libomp140.x86_64.dll"
+
+
+def _is_dll_load_failure(exc: BaseException) -> bool:
+    """True when an import failed because the OS could not load a native
+    library, rather than because a Python module was absent.
+
+    Windows raises ``ImportError: DLL load failed while importing _C``;
+    Linux/macOS raise ``ImportError: lib*.so: cannot open shared object
+    file`` or a dlopen error. Both mean "the .pyd/.so is there, its
+    dependencies are not" -- a different remediation from a missing
+    package.
+    """
+    if isinstance(exc, ModuleNotFoundError):
+        return False
+    text = str(exc).lower()
+    if "dll load failed" in text:
+        return True
+    if "cannot open shared object file" in text:
+        return True
+    if getattr(exc, "winerror", None) == 126:  # ERROR_MOD_NOT_FOUND
+        return True
+    return False
+
+
+def _torch_lib_dir(torch_root: str) -> Optional[str]:
+    if not torch_root or torch_root == "<not found on sys.path>":
+        return None
+    lib_dir = os.path.join(torch_root, "lib")
+    return lib_dir if os.path.isdir(lib_dir) else None
+
+
+def _list_dlls(directory: str) -> List[str]:
+    """Native libraries in `directory`, sorted. Never raises."""
+    suffixes = (".dll", ".so", ".dylib", ".pyd")
+    try:
+        return sorted(
+            name
+            for name in os.listdir(directory)
+            if name.lower().endswith(suffixes)
+        )
+    except BaseException:  # noqa: BLE001 -- unreadable dir is a datapoint
+        return []
+
+
+def _torch_native_payload_context(torch_root: str) -> str:
+    """Inventory fragment for a DLL-load failure detail.
+
+    Says whether torch/lib/ exists and how many native libraries are in
+    it. Zero (or a missing directory) is conclusive: the native payload
+    did not survive install, and no amount of re-extracting a short
+    bundle will conjure it back.
+    """
+    lib_dir = _torch_lib_dir(torch_root)
+    if lib_dir is None:
+        expected = (
+            os.path.join(torch_root, "lib")
+            if torch_root and torch_root != "<not found on sys.path>"
+            else "<unknown>"
+        )
+        return f" | torch_lib_dir={expected} | torch_lib_dir_exists=False"
+    dlls = _list_dlls(lib_dir)
+    frag = f" | torch_lib_dir={lib_dir} | torch_lib_count={len(dlls)}"
+    if sys.platform == "win32":
+        frag += f" | {_TORCH_EXTERNAL_DLL}={_TORCH_EXTERNAL_DLL in dlls}"
+    return frag
+
+
+def _torch_install_roots() -> List[str]:
+    """Every sys.path entry that contains a `torch` package directory.
+
+    Issue #79 surfaced an install with torch under
+    ``runtime/py/python/lib/site-packages`` while the launcher exported
+    ``runtime/py/python/site-packages`` on PYTHONPATH. When two trees
+    exist, a repair that rewrites one can leave the other -- the one
+    actually imported -- untouched, so the failure survives a "repair
+    succeeded" message. Listing them makes that visible in the bundle.
+    """
+    roots: List[str] = []
+    for entry in sys.path:
+        if not entry:
+            continue
+        try:
+            candidate = os.path.join(entry, "torch")
+            if os.path.isdir(candidate) and candidate not in roots:
+                roots.append(candidate)
+        except BaseException:  # noqa: BLE001
+            continue
+    return roots
+
+
+def _check_torch_dlls() -> CheckResult:
+    """Inventory torch's native payload (issue #79).
+
+    torch_intact tells you the import failed. This tells you WHY when
+    the cause is native: whether torch/lib/ survived install, how many
+    libraries are in it, whether the classic missing external dependency
+    is present, and whether more than one torch tree is installed.
+
+    Deliberately never imports torch -- it runs even when the import
+    that motivated it crashes the interpreter.
+    """
+    torch_root = _resolve_pkg_root("torch")
+    if torch_root == "<not found on sys.path>":
+        # torch_intact already reports this; don't double-flag it.
+        return CheckResult(
+            "torch_dlls",
+            "warn",
+            "torch is not on sys.path -- see torch_intact for the cause.",
+        )
+
+    roots = _torch_install_roots()
+    multi = ""
+    if len(roots) > 1:
+        multi = (
+            f" WARNING: {len(roots)} torch trees on sys.path ({'; '.join(roots)}) "
+            "-- a repair may rewrite one while the interpreter imports the "
+            "other. Remove the stale copy."
+        )
+
+    lib_dir = _torch_lib_dir(torch_root)
+    if lib_dir is None:
+        return CheckResult(
+            "torch_dlls",
+            "error",
+            f"torch/lib/ is missing entirely (expected at "
+            f"{os.path.join(torch_root, 'lib')}). torch's native libraries "
+            "did not survive install -- antivirus quarantine or a truncated "
+            "extract. Run [Add AV Exclusion] then [Repair PyTorch via pip]."
+            + multi,
+        )
+
+    dlls = _list_dlls(lib_dir)
+    if not dlls:
+        return CheckResult(
+            "torch_dlls",
+            "error",
+            f"torch/lib/ exists at {lib_dir} but contains no native "
+            "libraries. Same failure class as a missing directory: run "
+            "[Add AV Exclusion] then [Repair PyTorch via pip]." + multi,
+        )
+
+    if sys.platform == "win32" and _TORCH_EXTERNAL_DLL not in dlls:
+        return CheckResult(
+            "torch_dlls",
+            "warn",
+            f"{len(dlls)} native librar(ies) in {lib_dir}, but "
+            f"{_TORCH_EXTERNAL_DLL} is not among them. torch's fbgemm.dll "
+            "depends on it, and its absence is a common cause of "
+            "'DLL load failed while importing _C'. If torch_intact reports "
+            "that error, run [Repair PyTorch via pip]." + multi,
+        )
+
+    status = "warn" if multi else "ok"
+    return CheckResult(
+        "torch_dlls",
+        status,
+        f"{len(dlls)} native librar(ies) present in {lib_dir}." + multi,
+    )
+
+
 def _check_torch_intact() -> CheckResult:
     # The whole reason this doctor exists: a previous build prune
     # deleted torch/testing/. Verify the FULL torch surface, not
@@ -251,11 +417,26 @@ def _check_torch_intact() -> CheckResult:
             m = _re.search(r"No module named '([^']+)'", str(e))
             missing = m.group(1) if m else ""
 
+        # Issue #79: a DLL-load failure is a DIFFERENT bug class from a
+        # missing Python module, and reporting it as one is actively
+        # misleading. `ImportError: DLL load failed while importing _C`
+        # means Python FOUND torch/_C.pyd and the OS then refused to
+        # load it -- because a native dependency in torch/lib/ (or an
+        # external one like libomp140.x86_64.dll) could not be
+        # resolved. The old code labelled that `missing_module=_C`,
+        # which reads as "the _C package is gone" and sends the
+        # operator looking for a Python file that is sitting right
+        # there.
+        dll_failure = _is_dll_load_failure(e)
+
         detail = (
             f"{type(e).__name__}: {e} | torch_root={torch_root} | "
             f"torch_testing_dir_exists={testing_exists}"
         )
-        if missing:
+        if dll_failure:
+            detail += " | failure_class=dll_load"
+            detail += _torch_native_payload_context(torch_root)
+        elif missing:
             detail += f" | missing_module={missing}"
             detail += _missing_submodule_context(torch_root, missing)
         detail += ". "
@@ -265,7 +446,20 @@ def _check_torch_intact() -> CheckResult:
         # the shipped zip never contained sends users in a circle --
         # which is exactly what issue #75 reported after following the
         # old advice.
-        if missing and missing != "torch.testing" and testing_exists:
+        if dll_failure:
+            detail += (
+                "The Python side of torch is present but its native "
+                "libraries could not be loaded -- see the torch_dlls row "
+                "below for which files are on disk. Re-extracting the "
+                "runtime only helps if antivirus removed the DLLs after "
+                "install, so do it in this order: [Add AV Exclusion], then "
+                "[Repair PyTorch via pip] (Settings -> System Tools), which "
+                "downloads a complete torch wheel from upstream and is the "
+                "reliable fix when the bundled payload itself is short. "
+                "[Repair Runtime] alone re-extracts the same files and will "
+                "not add a DLL the bundle never had."
+            )
+        elif missing and missing != "torch.testing" and testing_exists:
             detail += (
                 f"The rest of torch is present, so this is not a broad "
                 f"quarantine -- '{missing}' alone is missing from the "
@@ -433,6 +627,7 @@ def run_selftest(data_dir: Optional[str] = None) -> DoctorReport:
         _check_python_boot,
         _check_vc_redist,
         _check_torch_intact,
+        _check_torch_dlls,
         _check_torchvision_intact,
         _check_numpy_intact,
         _check_fastapi_intact,
@@ -444,6 +639,7 @@ def run_selftest(data_dir: Optional[str] = None) -> DoctorReport:
         _check_python_boot: "python_boot",
         _check_vc_redist: "vc_redist",
         _check_torch_intact: "torch_intact",
+        _check_torch_dlls: "torch_dlls",
         _check_torchvision_intact: "torchvision_intact",
         _check_numpy_intact: "numpy_intact",
         _check_fastapi_intact: "fastapi_intact",

--- a/tauri-ui/main.js
+++ b/tauri-ui/main.js
@@ -2285,6 +2285,7 @@ async function checkInstallHealth() {
         python_boot:           "Bundled Python boots",
         vc_redist:             "Visual C++ runtime",
         torch_intact:          "PyTorch (incl. torch.testing)",
+        torch_dlls:            "PyTorch native libraries",
         torchvision_intact:    "torchvision",
         numpy_intact:          "NumPy (incl. numpy.testing)",
         fastapi_intact:        "FastAPI / uvicorn",
@@ -2450,8 +2451,27 @@ async function checkInstallHealth() {
       remediation + (lines ? `<div style='margin-top:10px;'><b>Detected:</b><ul style='margin:6px 0 0 20px;'>${lines}</ul></div>` : "");
 
     banner.hidden = false;
+    // Issue #79: this used to log only `h.issues`, the LEGACY string
+    // array that install_health builds from its own rows. The runtime
+    // doctor's failures are merged into `h.checks` (and can push the
+    // verdict to "error") without ever touching `h.issues` -- so a user
+    // whose only fault was a doctor row saw the bare line
+    // "Install health: ERROR --" with nothing after the dashes, in a
+    // log they were then asked to paste into a bug report.
+    //
+    // Prefer the merged checks; fall back to the legacy array for older
+    // shells that don't emit `checks`.
+    const reported = (errs.length ? errs : warns)
+      .map(c => {
+        const label = (c.label || c.id || "").toString().trim();
+        const message = (c.message || "").toString().trim();
+        return label && message ? `${label}: ${message}` : (label || message);
+      })
+      .filter(Boolean);
+    const summary = reported.length ? reported : (h.issues || []);
     logToTerminal(
-      `Install health: ${verdict.toUpperCase()} -- ` + (h.issues || []).join("; "),
+      `Install health: ${verdict.toUpperCase()} -- ` +
+        (summary.length ? summary.join("; ") : "no per-check detail reported"),
       logSeverity
     );
     // NOTE: install-health-dismiss / install-health-open-diagnosis click

--- a/tests/test_issue_79_regressions.py
+++ b/tests/test_issue_79_regressions.py
@@ -1,0 +1,398 @@
+"""
+Regression tests for GitHub issue #79 ("Backend failed to start", v0.2.5).
+
+The bundle in #79 contained three separate defects, only one of which
+was the user's actual machine problem:
+
+  1. `ImportError: DLL load failed while importing _C` was reported as
+     `missing_module=_C` with remediation text about re-extracting the
+     runtime. A DLL-load failure means the .pyd was FOUND and the OS
+     could not resolve its native dependencies -- a different bug class
+     with a different fix. The old wording sent the operator looking for
+     a Python module that was sitting right there, and recommended
+     [Repair Runtime], which cannot add a DLL the bundle never had.
+
+  2. The system probe reported ALL 11 critical bundled files as
+     `"status": "missing"` on a machine whose sidecar was running
+     happily off those very files. `deep_probe` passed the DATA root
+     (%LOCALAPPDATA%\\com.bot.mmorpg.ai) to `_file_integrity`, whose
+     paths are relative to the INSTALL root (C:\\Program Files\\...).
+
+  3. The in-app log line read `Install health: ERROR --` with nothing
+     after the dashes. Runtime-doctor failures are merged into
+     `h.checks` and can push the verdict to "error", but the log line
+     was built only from the legacy `h.issues` array, which the merge
+     never touches.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DOCTOR_PATH = ROOT / "scripts" / "runtime_doctor.py"
+UI_JS = ROOT / "tauri-ui" / "main.js"
+
+# Verbatim from the #79 debug bundle.
+DLL_ERROR_MESSAGE = (
+    "DLL load failed while importing _C: The specified module could not be found."
+)
+
+
+@pytest.fixture(scope="module")
+def doctor():
+    spec = importlib.util.spec_from_file_location("runtime_doctor_i79", DOCTOR_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["runtime_doctor_i79"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _torch_tree(tmp_path, *, lib_dlls=None, testing=False):
+    """Build a fake installed-torch directory."""
+    root = tmp_path / "site-packages" / "torch"
+    root.mkdir(parents=True)
+    if testing:
+        (root / "testing").mkdir()
+    if lib_dlls is not None:
+        lib = root / "lib"
+        lib.mkdir()
+        for name in lib_dlls:
+            (lib / name).write_bytes(b"MZ")
+    return root
+
+
+def _fail_torch_import(monkeypatch, exc: BaseException):
+    import importlib as _il
+
+    real_import = _il.import_module
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torch":
+            raise exc
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(_il, "import_module", fake_import)
+
+
+# =====================================================================
+# 1. DLL-load failures are their own bug class
+# =====================================================================
+
+
+def test_dll_load_failure_is_classified(doctor):
+    assert doctor._is_dll_load_failure(ImportError(DLL_ERROR_MESSAGE))
+    # Linux/macOS wording for the same underlying fault.
+    assert doctor._is_dll_load_failure(
+        ImportError("libtorch_cpu.so: cannot open shared object file")
+    )
+    # ERROR_MOD_NOT_FOUND surfaced as an OSError.
+    err = OSError("The specified module could not be found")
+    err.winerror = 126
+    assert doctor._is_dll_load_failure(err)
+
+
+def test_missing_module_is_not_a_dll_failure(doctor):
+    """A genuinely absent package must keep the issue #75 remediation."""
+    assert not doctor._is_dll_load_failure(
+        ModuleNotFoundError(
+            "No module named 'torch._strobelight'", name="torch._strobelight"
+        )
+    )
+    assert not doctor._is_dll_load_failure(
+        ModuleNotFoundError("No module named 'torch'")
+    )
+
+
+def test_torch_intact_reports_dll_class_not_a_missing_module(
+    doctor, monkeypatch, tmp_path
+):
+    """The #79 bundle verbatim: `_C` reported as if the module vanished."""
+    root = _torch_tree(tmp_path, lib_dlls=["c10.dll", "torch_cpu.dll"])
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    # CPython sets .name to the leaf module for a native import failure.
+    exc = ImportError(DLL_ERROR_MESSAGE, name="_C")
+    _fail_torch_import(monkeypatch, exc)
+
+    result = doctor._check_torch_intact()
+
+    assert result.status == "error"
+    assert "failure_class=dll_load" in result.detail
+    assert "missing_module=_C" not in result.detail, (
+        "Reporting a DLL-load failure as a missing Python module is what "
+        "sent issue #79 after the wrong file."
+    )
+
+
+def test_torch_intact_dll_failure_carries_native_inventory(
+    doctor, monkeypatch, tmp_path
+):
+    root = _torch_tree(tmp_path, lib_dlls=["c10.dll", "torch_cpu.dll", "fbgemm.dll"])
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    _fail_torch_import(monkeypatch, ImportError(DLL_ERROR_MESSAGE, name="_C"))
+
+    detail = doctor._check_torch_intact().detail
+
+    assert "torch_lib_count=3" in detail
+    assert str(root / "lib") in detail
+
+
+def test_torch_intact_dll_failure_recommends_pip_repair_over_reextract(
+    doctor, monkeypatch, tmp_path
+):
+    """[Repair Runtime] re-extracts the same bundle. If the bundle's
+    native payload is short, that is a no-op -- and #79's user ran it."""
+    root = _torch_tree(tmp_path, lib_dlls=[])
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    _fail_torch_import(monkeypatch, ImportError(DLL_ERROR_MESSAGE, name="_C"))
+
+    detail = doctor._check_torch_intact().detail
+
+    assert "Repair PyTorch via pip" in detail
+    assert "will not add a DLL the bundle never had" in detail
+
+
+def test_torch_intact_keeps_issue_75_wording_for_missing_modules(
+    doctor, monkeypatch, tmp_path
+):
+    """Guard against the #79 fix regressing the #75 fix."""
+    root = _torch_tree(tmp_path, lib_dlls=["c10.dll"], testing=True)
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    _fail_torch_import(
+        monkeypatch,
+        ModuleNotFoundError(
+            "No module named 'torch._strobelight'", name="torch._strobelight"
+        ),
+    )
+
+    detail = doctor._check_torch_intact().detail
+
+    assert "missing_module=torch._strobelight" in detail
+    assert "failure_class=dll_load" not in detail
+    assert "not a broad" in detail
+
+
+# =====================================================================
+# 2. The torch_dlls check
+# =====================================================================
+
+
+def test_torch_dlls_is_a_registered_check(doctor):
+    """It must appear in the report, not just exist as a function --
+    an unregistered check diagnoses nothing."""
+    report = doctor.run_selftest()
+    names = {c.name for c in report.checks}
+    assert "torch_dlls" in names
+    # Stable ordering: the inventory reads directly after the import it
+    # explains.
+    ordered = [c.name for c in report.checks]
+    assert ordered.index("torch_dlls") == ordered.index("torch_intact") + 1
+
+
+def test_torch_dlls_errors_when_lib_dir_is_gone(doctor, monkeypatch, tmp_path):
+    root = _torch_tree(tmp_path)  # no lib/ at all
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    monkeypatch.setattr(doctor, "_torch_install_roots", lambda: [str(root)])
+
+    result = doctor._check_torch_dlls()
+
+    assert result.status == "error"
+    assert "torch/lib/ is missing entirely" in result.detail
+    assert "Repair PyTorch via pip" in result.detail
+
+
+def test_torch_dlls_errors_on_empty_lib_dir(doctor, monkeypatch, tmp_path):
+    root = _torch_tree(tmp_path, lib_dlls=[])
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    monkeypatch.setattr(doctor, "_torch_install_roots", lambda: [str(root)])
+
+    result = doctor._check_torch_dlls()
+
+    assert result.status == "error"
+    assert "contains no native" in result.detail
+
+
+def test_torch_dlls_ok_when_payload_present(doctor, monkeypatch, tmp_path):
+    root = _torch_tree(
+        tmp_path, lib_dlls=["c10.dll", "torch_cpu.dll", doctor._TORCH_EXTERNAL_DLL]
+    )
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    monkeypatch.setattr(doctor, "_torch_install_roots", lambda: [str(root)])
+
+    result = doctor._check_torch_dlls()
+
+    assert result.status == "ok"
+    assert "3 native" in result.detail
+
+
+def test_torch_dlls_warns_on_split_installation(doctor, monkeypatch, tmp_path):
+    """#79's runtime had torch under `python/lib/site-packages` while the
+    launcher exported `python/site-packages` on PYTHONPATH. A repair can
+    rewrite one tree while the interpreter imports the other."""
+    root = _torch_tree(tmp_path, lib_dlls=["c10.dll", doctor._TORCH_EXTERNAL_DLL])
+    other = tmp_path / "lib" / "site-packages" / "torch"
+    other.mkdir(parents=True)
+    monkeypatch.setattr(doctor, "_resolve_pkg_root", lambda pkg: str(root))
+    monkeypatch.setattr(doctor, "_torch_install_roots", lambda: [str(root), str(other)])
+
+    result = doctor._check_torch_dlls()
+
+    assert result.status == "warn"
+    assert "2 torch trees" in result.detail
+    assert str(other) in result.detail
+
+
+def test_torch_dlls_defers_to_torch_intact_when_torch_is_absent(doctor, monkeypatch):
+    monkeypatch.setattr(
+        doctor, "_resolve_pkg_root", lambda pkg: "<not found on sys.path>"
+    )
+    result = doctor._check_torch_dlls()
+    assert result.status == "warn"
+    assert "see torch_intact" in result.detail
+
+
+def test_torch_install_roots_finds_every_tree(doctor, monkeypatch, tmp_path):
+    a = tmp_path / "a" / "site-packages"
+    b = tmp_path / "b" / "lib" / "site-packages"
+    (a / "torch").mkdir(parents=True)
+    (b / "torch").mkdir(parents=True)
+    monkeypatch.setattr(
+        doctor.sys, "path", [str(a), str(b), "", str(tmp_path / "empty")]
+    )
+
+    roots = doctor._torch_install_roots()
+
+    assert roots == [str(a / "torch"), str(b / "torch")]
+
+
+def test_native_payload_context_handles_unresolvable_roots(doctor):
+    """Never raise on a torch we could not locate."""
+    frag = doctor._torch_native_payload_context("<not found on sys.path>")
+    assert "torch_lib_dir_exists=False" in frag
+
+
+# =====================================================================
+# 3. file_integrity looked in the wrong tree
+# =====================================================================
+
+
+def test_deep_probe_checks_file_integrity_against_the_resource_root(
+    monkeypatch, tmp_path
+):
+    """The #79 bundle flagged all 11 shipped files missing because the
+    probe searched the data root."""
+    from modelhub.diagnostics import health_probe  # noqa: PLC0415
+
+    data_root = tmp_path / "AppData" / "Local" / "com.bot.mmorpg.ai"
+    resource_root = tmp_path / "Program Files" / "BOT-MMORPG-AI"
+    data_root.mkdir(parents=True)
+    resource_root.mkdir(parents=True)
+
+    # Lay down the shipped files where they really live.
+    for rel in health_probe._CRITICAL_FILES:
+        target = resource_root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"payload")
+
+    monkeypatch.setenv("MODELHUB_DATA_ROOT", str(data_root))
+    monkeypatch.setenv("MODELHUB_RESOURCE_ROOT", str(resource_root))
+
+    out = health_probe.deep_probe()
+
+    statuses = {row["path"]: row["status"] for row in out["file_integrity"]}
+    missing = sorted(p for p, s in statuses.items() if s == "missing")
+    assert not missing, f"present files reported missing: {missing}"
+    assert out["resource_root"] == str(resource_root.resolve())
+    assert out["data_root"] == str(data_root.resolve())
+
+
+def test_deep_probe_still_reports_genuinely_missing_files(monkeypatch, tmp_path):
+    """The fix must not turn the check into a rubber stamp."""
+    from modelhub.diagnostics import health_probe  # noqa: PLC0415
+
+    data_root = tmp_path / "data"
+    resource_root = tmp_path / "install"
+    data_root.mkdir()
+    resource_root.mkdir()
+    monkeypatch.setenv("MODELHUB_DATA_ROOT", str(data_root))
+    monkeypatch.setenv("MODELHUB_RESOURCE_ROOT", str(resource_root))
+
+    out = health_probe.deep_probe()
+
+    statuses = {row["status"] for row in out["file_integrity"]}
+    assert statuses == {"missing"}
+
+
+def test_deep_probe_falls_back_to_the_data_root(monkeypatch, tmp_path):
+    """Callers with one combined tree (and no MODELHUB_RESOURCE_ROOT)
+    must behave exactly as before."""
+    from modelhub.diagnostics import health_probe  # noqa: PLC0415
+
+    combined = tmp_path / "combined"
+    combined.mkdir()
+    monkeypatch.setenv("MODELHUB_DATA_ROOT", str(combined))
+    monkeypatch.delenv("MODELHUB_RESOURCE_ROOT", raising=False)
+    monkeypatch.delenv("BOT_INSTALL_DIR", raising=False)
+
+    out = health_probe.deep_probe()
+
+    assert out["resource_root"] == str(combined.resolve())
+
+
+def test_resolve_resource_root_ignores_a_nonexistent_env_path(monkeypatch, tmp_path):
+    from modelhub.diagnostics import health_probe  # noqa: PLC0415
+
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    monkeypatch.setenv(
+        "MODELHUB_RESOURCE_ROOT", str(tmp_path / "does" / "not" / "exist")
+    )
+
+    assert health_probe._resolve_resource_root(data_root) == data_root
+
+
+# =====================================================================
+# 4. "Install health: ERROR --" with no reason
+# =====================================================================
+
+
+def test_install_health_log_line_uses_the_merged_checks():
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    start = js.index("banner.hidden = false;")
+    end = js.index("install-health-dismiss", start)
+    block = js[start:end]
+
+    assert "h.issues" in block, "legacy fallback should still be present"
+    assert re.search(r"errs\.length\s*\?\s*errs\s*:\s*warns", block), (
+        "The log line must be built from the merged `checks` array -- "
+        "runtime-doctor failures never appear in the legacy `h.issues` "
+        "array, which is why issue #79 logged a bare 'ERROR --'."
+    )
+    assert "no per-check detail reported" in block, (
+        "An error verdict with nothing after the dashes is unusable in a "
+        "pasted bug report; say so explicitly instead."
+    )
+
+
+def test_doctor_rows_have_ui_labels():
+    """A doctor check with no labelMap entry renders its raw snake_case
+    name in the banner."""
+    js = UI_JS.read_text(encoding="utf-8", errors="replace")
+    start = js.index("const labelMap = {")
+    end = js.index("};", start)
+    labelled = set(re.findall(r"(\w+):\s*\"", js[start:end]))
+
+    doctor_src = DOCTOR_PATH.read_text(encoding="utf-8", errors="replace")
+    reg_start = doctor_src.index("    name_for: dict = {")
+    reg_end = doctor_src.index("    }", reg_start)
+    registered = set(re.findall(r':\s*"(\w+)"', doctor_src[reg_start:reg_end]))
+    registered.add("data_dir_writable")  # supplied via the lambda default
+
+    unlabelled = sorted(registered - labelled)
+    assert not unlabelled, f"doctor checks with no UI label: {unlabelled}"


### PR DESCRIPTION
Diagnose torch DLL-load failures correctly; fix two probe defects
Issue https://github.com/ruslanmv/BOT-MMORPG-AI/issues/79 (v0.2.5 debug bundle).

torch DLL-load failures are a distinct bug class
------------------------------------------------
`ImportError: DLL load failed while importing _C` was reported as
`missing_module=_C` with remediation text about re-extracting the
runtime. That message means the opposite of what it was labelled: the
.pyd was found and the OS could not resolve its native dependencies. The
operator was sent looking for a Python module sitting right there, and
told to run [Repair Runtime], which cannot add a DLL the bundle never
had -- https://github.com/ruslanmv/BOT-MMORPG-AI/issues/79's log tail shows them doing exactly that.

The doctor now classifies DLL-load failures (Windows "DLL load failed",
POSIX "cannot open shared object file", WinError 126) separately, tags
them `failure_class=dll_load`, and attaches a torch/lib inventory. Its
remediation orders [Add AV Exclusion] -> [Repair PyTorch via pip] and
says plainly why re-extracting alone will not help. The issue https://github.com/ruslanmv/BOT-MMORPG-AI/issues/75
missing-module wording is unchanged for genuine ModuleNotFoundErrors.

New `torch_dlls` check
----------------------
torch_intact says the import failed; this says why when the cause is
native. Reports whether torch/lib/ survived install, how many libraries
are in it, and whether libomp140.x86_64.dll (fbgemm's dependency, not
part of the VC++ redist, so vc_redist passing says nothing about it) is
present. Never imports torch, so it runs even when that import is what
crashes.

It also flags split installations: https://github.com/ruslanmv/BOT-MMORPG-AI/issues/79's runtime had torch under
runtime/py/python/lib/site-packages while the launcher exported
runtime/py/python/site-packages on PYTHONPATH. With two trees a repair
can rewrite one while the interpreter imports the other, so a "repair
succeeded" message is followed by an unchanged failure.

DOCTOR_VERSION -> 1.2.0.

System probe reported every shipped file as missing
---------------------------------------------------
deep_probe passed the DATA root to _file_integrity, whose paths are
relative to the INSTALL root -- two different trees since the MVP-1
migration. All 11 critical files were flagged missing on a machine whose
sidecar was running off those very files, which makes a bundle look
catastrophic and buries the real fault. File integrity now resolves the
resource root (MODELHUB_RESOURCE_ROOT), falling back to the data root so
single-tree callers are unaffected. Both roots are reported.

"Install health: ERROR --" with no reason
-----------------------------------------
Runtime-doctor failures are merged into h.checks and can push the
verdict to "error", but the log line was built only from the legacy
h.issues array, which the merge never touches. A user whose only fault
was a doctor row saw a bare "ERROR --" in the log they were then asked
to paste into a bug report. Now built from the merged checks, with the
legacy array as fallback. Added the torch_dlls UI label.

Tests
-----
tests/test_issue_79_regressions.py (20 tests); 17 fail against the
pre-fix tree, the other 3 are invariant