### PR TITLE
Bot mmorpg ai issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The sidecar no longer fails with `No module named 'uvicorn'` after a
+  pip-based runtime repair. The backend now adds both
+  `<prefix>\site-packages` (the build's install target) and
+  `<prefix>\Lib\site-packages` (where `pip install` repairs land) to its
+  path, so packages reinstalled by "Repair PyTorch via pip" are actually
+  importable instead of sitting in a directory the sidecar never looked
+  at. Note: a torch broken by antivirus quarantine is a separate axis —
+  add the AV exclusion first, then repair (issue #85).
 - The sidecar starts on Python 3.9 again. One route annotation used the
   3.10+ `Dict[str, Any] | None` spelling; FastAPI evaluates route
   annotations at registration time, so `create_app()` itself raised

--- a/backend/entry_main.py
+++ b/backend/entry_main.py
@@ -109,12 +109,62 @@ def _bootstrap_sys_path() -> None:
             sys.path.insert(0, path_str)
 
 
+def _bootstrap_site_packages() -> None:
+    """Put THIS interpreter's own site-packages onto sys.path.
+
+    The bundled runtime installs third-party deps (fastapi, uvicorn,
+    torch, numpy, ...) into the embedded interpreter, and the sidecar is
+    supposed to see them via the patched `pythonXY._pth` + `import site`.
+    Two things break that in the field (issue #85):
+
+      * The Rust supervisor passes an explicit ``PYTHONPATH`` that lists
+        ``runtime\\py\\python\\site-packages`` (the build's
+        ``pip --target`` location) but NOT the interpreter's standard
+        ``Lib\\site-packages``. Any repair that shells out to
+        ``pip install`` -- including the app's own "Repair PyTorch via
+        pip" -- writes to ``Lib\\site-packages`` by default, so those
+        packages land in a directory the sidecar never adds. The result
+        is exactly the reported failure: ``No module named 'uvicorn'``
+        with a second, shadow ``torch`` tree the doctor warns about.
+      * If a repair rewrites ``pythonXY._pth`` without ``import site``,
+        the whole site machinery goes quiet and even ``site-packages``
+        stops resolving.
+
+    Adding both site directories, derived from ``sys.executable`` /
+    ``sys.prefix`` at runtime, makes the sidecar self-sufficient: it
+    finds its own installed packages no matter which location a repair
+    used and regardless of the supervisor-supplied PYTHONPATH. Appended
+    (not inserted at front) so a project checkout on ``sys.path[0]`` still
+    wins; guarded by ``is_dir()`` so nonexistent paths are skipped; and
+    wrapped so this never raises (a bad path must not abort startup).
+    """
+    try:
+        roots = {Path(sys.prefix)}
+        try:
+            roots.add(Path(sys.executable).resolve().parent)
+        except (OSError, ValueError):
+            pass
+
+        # Both layouts the bundled runtime can present:
+        #   <prefix>\site-packages     -- pip install --target (build)
+        #   <prefix>\Lib\site-packages -- standard install (pip repair)
+        for root in roots:
+            for rel in ("site-packages", os.path.join("Lib", "site-packages")):
+                sp = root / rel
+                sp_str = str(sp)
+                if sp_str not in sys.path and sp.is_dir():
+                    sys.path.append(sp_str)
+    except Exception:  # noqa: BLE001 -- bootstrapping must never raise
+        pass
+
+
 def main() -> int:
     # Bootstrap BEFORE the import. If we leave it inside the try/except
     # below, an exception here gets swallowed into the FAILED line --
     # which is fine, but bootstrapping should never raise (we use
     # try/except inside _bootstrap_sys_path to be sure).
     _bootstrap_sys_path()
+    _bootstrap_site_packages()
 
     # Top-level safety net so EVERY launch failure produces a uniform,
     # parseable marker. Without this, an ImportError in

--- a/docs/installer/04-bug-index.md
+++ b/docs/installer/04-bug-index.md
@@ -185,6 +185,58 @@ those directories present.
   auto-generated). Keep everything else pip installed.
 - **See:** `05-case-studies.md` Bug #10.
 
+### `No module named 'uvicorn'` on a machine where numpy/cv2 import fine, with two `torch` trees
+
+Distinct from the "uvicorn entry point" bug above (that ships a broken
+zip). Here the shipped zip is fine — the build's **mandatory** runtime
+integrity check (`build_pipeline.ps1`, `import fastapi, uvicorn` +
+dist-info asserts) cannot pass otherwise — but the *per-user* runtime at
+`%LOCALAPPDATA%\com.bot.mmorpg.ai\runtime\py\python\` has drifted into a
+mixed state.
+
+**Distinguishing signals** (all present in issue #85):
+
+- `numpy` and `cv2` import OK, but `uvicorn` is *entirely* missing and
+  `fastapi` fails on a transitive dep (`typing_inspection`).
+- The runtime doctor's `torch_dlls` row warns **"2 torch trees on
+  sys.path"**: `...\site-packages\torch` **and**
+  `...\Lib\site-packages\torch`.
+- The sidecar's `PYTHONPATH` (in the debug bundle's Environment block)
+  lists `...\runtime\py\python\site-packages` but **not**
+  `...\runtime\py\python\Lib\site-packages`.
+
+**Root cause.** The build installs deps with `pip --target site-packages`
+(a flat `site-packages`), and the Rust supervisor puts exactly that
+directory on the sidecar's `PYTHONPATH`. But every pip-based repair —
+including the app's own **Repair PyTorch via pip** — installs into the
+interpreter's *standard* `Lib\site-packages`. Anything a repair (re)installs
+lands in a directory the sidecar never added, so a repaired `uvicorn`/
+`torch` is invisible to it even though it is on disk. That is why the
+user's repeated Repair Runtime / Repair PyTorch clicks never recovered
+the sidecar.
+
+- **File:** `backend/entry_main.py` (`_bootstrap_site_packages`).
+- **Fix:** the sidecar now appends **both** `<prefix>\site-packages` and
+  `<prefix>\Lib\site-packages` (derived from `sys.prefix`/
+  `sys.executable`) to `sys.path` at startup, so it finds its own
+  installed packages regardless of which location a repair used and
+  regardless of the supervisor-supplied `PYTHONPATH`. Guarded by
+  `test_backend_startup.py::TestSidecarSitePackagesBootstrap`.
+- **Still needed on the AV axis:** the broken `torch` in this bundle
+  (missing `torch/lib/`, `torch._strobelight`) is the separate
+  AV-quarantine problem — see the `torch.testing` AV entry above. The
+  path fix makes a *successful* pip-repair actually take effect; it does
+  not stop AV from re-quarantining torch. Add the AV exclusion first.
+- **End-user recovery (no rebuild), simplest first:**
+  1. Fully delete `%LOCALAPPDATA%\com.bot.mmorpg.ai\runtime`, then
+     relaunch — the app re-extracts a clean runtime with no stale
+     second tree.
+  2. Or reinstall the backend deps into the bundled interpreter:
+     ```powershell
+     & "$env:LOCALAPPDATA\com.bot.mmorpg.ai\runtime\py\python\python.exe" `
+       -m pip install --upgrade fastapi "uvicorn[standard]"
+     ```
+
 ### "Sidecar API not ready after 5 s"
 
 The Python sidecar didn't print `READY url=...` to stdout within 5

--- a/tests/test_backend_startup.py
+++ b/tests/test_backend_startup.py
@@ -5,7 +5,94 @@ Validates that main_backend.py correctly parses CLI args and forwards
 them to modelhub.tauri with the right parameter names.
 """
 
+import importlib.util
+import pathlib
+import sys
+
 from unittest.mock import MagicMock, patch
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_entry_main():
+    """Import backend/entry_main.py under a unique name."""
+    spec = importlib.util.spec_from_file_location(
+        "entry_main_under_test", ROOT / "backend" / "entry_main.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["entry_main_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestSidecarSitePackagesBootstrap:
+    """Issue #85: the sidecar must find its own interpreter's packages.
+
+    The bundled runtime can hold third-party deps in either
+    ``<prefix>\\site-packages`` (the build's ``pip --target``) or
+    ``<prefix>\\Lib\\site-packages`` (where a pip-based repair installs).
+    The Rust supervisor only put the former on PYTHONPATH, so a repaired
+    ``uvicorn`` in the latter was invisible -> ``No module named
+    'uvicorn'``. entry_main now adds both, derived from sys.prefix.
+    """
+
+    def test_lib_site_packages_is_added_when_present(self, tmp_path, monkeypatch):
+        entry = _load_entry_main()
+
+        # A fake interpreter prefix whose deps live only in Lib/site-packages
+        # -- the location a `pip install` repair uses by default.
+        lib_sp = tmp_path / "Lib" / "site-packages"
+        lib_sp.mkdir(parents=True)
+
+        monkeypatch.setattr(sys, "prefix", str(tmp_path))
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "python.exe"))
+        monkeypatch.setattr(sys, "path", list(sys.path))
+
+        entry._bootstrap_site_packages()
+
+        assert str(lib_sp) in sys.path
+
+    def test_flat_site_packages_is_added_when_present(self, tmp_path, monkeypatch):
+        entry = _load_entry_main()
+
+        flat_sp = tmp_path / "site-packages"
+        flat_sp.mkdir()
+
+        monkeypatch.setattr(sys, "prefix", str(tmp_path))
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "python.exe"))
+        monkeypatch.setattr(sys, "path", list(sys.path))
+
+        entry._bootstrap_site_packages()
+
+        assert str(flat_sp) in sys.path
+
+    def test_missing_dirs_are_skipped_and_do_not_raise(self, tmp_path, monkeypatch):
+        entry = _load_entry_main()
+
+        monkeypatch.setattr(sys, "prefix", str(tmp_path))  # empty prefix
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "python.exe"))
+        before = list(sys.path)
+        monkeypatch.setattr(sys, "path", list(sys.path))
+
+        entry._bootstrap_site_packages()  # must not raise
+
+        # Nothing existed to add, so the path is unchanged.
+        assert sys.path == before
+
+    def test_bootstrap_is_idempotent(self, tmp_path, monkeypatch):
+        entry = _load_entry_main()
+
+        (tmp_path / "Lib" / "site-packages").mkdir(parents=True)
+        monkeypatch.setattr(sys, "prefix", str(tmp_path))
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "python.exe"))
+        monkeypatch.setattr(sys, "path", list(sys.path))
+
+        entry._bootstrap_site_packages()
+        entry._bootstrap_site_packages()
+
+        target = str(tmp_path / "Lib" / "site-packages")
+        assert sys.path.count(target) == 1
 
 
 class TestBackendArgParsing:


### PR DESCRIPTION
Fix https://github.com/ruslanmv/BOT-MMORPG-AI/issues/85: sidecar can't find backend deps a pip repair reinstalled
A fresh v0.2.7 install fails to start the backend with

  FAILED error=No module named 'uvicorn'

on a machine where numpy and cv2 import fine. The debug bundle's
distinguishing signals: uvicorn entirely absent, fastapi failing on a
transitive dep (typing_inspection), and the runtime doctor warning of
TWO torch trees on sys.path -- site-packages\torch AND
Lib\site-packages\torch -- while the sidecar's PYTHONPATH lists only the
former.

Root cause is not the build: build_pipeline.ps1 has a mandatory runtime
integrity check (import fastapi, uvicorn + dist-info asserts) that the
shipped zip must pass. It is the per-user runtime drifting. The build
installs deps with `pip --target site-packages` (a flat site-packages),
and the Rust supervisor puts exactly that directory on the sidecar's
PYTHONPATH -- but every pip-based repair, including the app's own
"Repair PyTorch via pip", installs into the interpreter's standard
Lib\site-packages. Anything a repair reinstalls lands in a directory the
sidecar never adds, so it stays invisible. That is why the user's
repeated Repair Runtime / Repair PyTorch clicks never recovered it.

entry_main.py now appends both <prefix>\site-packages and
<prefix>\Lib\site-packages (derived from sys.prefix / sys.executable) to
sys.path at startup, so the sidecar finds its own installed packages
regardless of which location a repair used and regardless of the
supervisor-supplied PYTHONPATH. Additive and guarded by is_dir(), so it
never shadows a project checkout and never raises.

The torch broken by AV quarantine (missing torch/lib/, torch._strobelight)
is a separate axis documented alongside; the path fix makes a successful
pip-repair take effect, it does not stop AV from re-quarantining torch.

Adds TestSidecarSitePackagesBootstrap (4 tests) and a bug-index entry
with the distinguishing signals and end-user recovery. Full suite: 574
passed, 3 skipped; ruff + format + ASCII guard clean.